### PR TITLE
Fixed admin choice and most common by adding a console.log #40

### DIFF
--- a/helpers/classes/stateMachine.js
+++ b/helpers/classes/stateMachine.js
@@ -171,6 +171,8 @@ class StateMachine {
                         let commoncards = mostcommon(this.session.dbData.features[this.session.featurePointer].votes
                                              .filter(vote => vote.round === 2).map(vote => vote.value))
 
+                        console.log(commoncards)
+
                         if(commoncards.length > 1)
                             this.session.admin.emit('admin', { event: 'chooseboth', members : members, cards: commoncards, data: this.session.featureData() });
                         else this.session.admin.emit('admin', { event: 'choose', members : members, cards: commoncards, data: this.session.featureData()});


### PR DESCRIPTION
Teststappen:

Maak een nieuwe sessie aan met 2 clients en kies beide een ander nummer.
De admin krijgt nu de keuze tussen de 2 nummers
Kies 1 van de nummers en submit
Het gekozen nummer klopt nu met het kaartje